### PR TITLE
'requirements.txt'文件名错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SourceLeakHacker is a muilt-threads web directories scanner.
 
 #### Installation
 ```
-pip install -r requirments.txt
+pip install -r requirements.txt
 ```
 
 #### Usage　


### PR DESCRIPTION
pip install -r requirments.txt运行失败，检查后发现文件名错误
修改为：pip install -r requirements.txt