### PR TITLE
fix output result foldername bug

### DIFF
--- a/SourceLeakHacker.py
+++ b/SourceLeakHacker.py
@@ -67,7 +67,7 @@ Examples:
 def save_dictionary(filename, dictionary):
     with open(filename, "w") as f:
         for k, v in dictionary.items():
-            f.write("{}-{}\n".format(v, k))
+            f.write("{}\t{}\n".format(v, k))
 
 def main():
     init()

--- a/SourceLeakHacker.py
+++ b/SourceLeakHacker.py
@@ -52,7 +52,7 @@ Examples:
     # parser.add_argument("--folders", default=context.foldernames_dictionary, help="dictionary for most common folder names, default: {}".format(context.foldernames_dictionary))
     # parser.add_argument("--files", default=context.filenames_dictionary, help="dictionary for most common file names, default: {}".format(context.filenames_dictionary))
     # parser.add_argument("--backups", default=context.backups_dictionary, help="dictionary for most common backup file patterns, default: {}".format(context.backups_dictionary))
-    parser.add_argument("--output", "-o", help="output folder, default: result/YYYY-MM-DD hh:mm:ss", default=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time())))
+    parser.add_argument("--output", "-o", help="output folder, default: result/YYYY-MM-DD-hh-mm-ss", default=time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime(time.time())))
 
     parser.add_argument("--threads", "-t", default=4, type=int, help="threads numbers, default: 4")
     parser.add_argument("--timeout", type=float, default=4, help="HTTP request timeout")
@@ -67,7 +67,7 @@ Examples:
 def save_dictionary(filename, dictionary):
     with open(filename, "w") as f:
         for k, v in dictionary.items():
-            f.write("{}\t{}\n".format(v, k))
+            f.write("{}-{}\n".format(v, k))
 
 def main():
     init()


### PR DESCRIPTION
在windows系统中，不能存在有:（冒号）的目录，所以无法生成result/xx-xx-xx 1:2:3/200.csv.
修改：替换了空格和:这个两个符号为-
为了预防一些奇奇怪怪的情况，建议还是将空格替换了。